### PR TITLE
fix: rewrite nested package-relative doc links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@
 
 The generator can produce API content from three sources:
 
-1. The installed package's `dist/docs.json` (when `adapter` is omitted). `!::Identifier::` placeholders can be used in **any page** to expand a `dist/docs.json` entry on its own line. The identifier must match the exact name in `dist/docs.json`.
+1. The installed package's `dist/docs.json` (when `adapter` is omitted). `!::Identifier::` placeholders can be used in **any page** to expand a `dist/docs.json` entry on its own line. The identifier must match the exact name in `dist/docs.json`. In package `docs/*.md` that GitHub renders, wrap the placeholder as `<!-- !::Identifier:: -->` so it is hidden on GitHub. The generator expands both the bare and commented forms.
 2. `<docgen-index>` + `<docgen-api>` blocks inside a `readme.md` (rdlabo Capacitor plugin landings).
 3. Hand-authored Markdown with semantic headings such as ``#### `method` foo``.
 

--- a/README.md
+++ b/README.md
@@ -64,8 +64,10 @@ npm run docs:generate
 Narrative documentation uses Zenn Markdown. Markdown-only projects take their displayed version from the exactly pinned installed package. Capacitor API entries are expanded from the installed package's pinned `dist/docs.json` with placeholders such as:
 
 ```md
-!::createPaymentSheet::
+<!-- !::createPaymentSheet:: -->
 ```
+
+The generator also accepts the bare `!::createPaymentSheet::` form. Package guides that GitHub renders should use the HTML-comment form so the placeholder stays hidden.
 
 Capacitor READMEs containing both `<docgen-index>` and `<docgen-api>` are automatically exposed as
 separate README and API pages. The source README remains the single file to update.

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -20,6 +20,7 @@ import { normalizeImportedReadmeHeadings } from './markdown-headings';
 import { splitDocgenReadme } from './docgen-readme';
 import {
   apiAnchorFragments,
+  expandApiPlaceholders,
   extractPackageReadmeParts,
   normalizePackageMarkdown,
   rewritePackageDocLinks,
@@ -423,12 +424,7 @@ async function generateProject(project: ProjectDefinition, locale: Locale): Prom
     annotateDocgen,
   } of sourcePages) {
     const { slug, file } = page;
-    const missingApiEntries: string[] = [];
-    const expanded = body.replace(/^!::([a-zA-Z0-9]+)::$/gm, (_, id: string) => {
-      const entry = api.get(id);
-      if (!entry) missingApiEntries.push(id);
-      return entry ?? '';
-    });
+    const { expanded, missing: missingApiEntries } = expandApiPlaceholders(body, api);
     if (missingApiEntries.length) {
       throw new Error(
         `${relative(root, sourcePath)} references missing API entries: ${missingApiEntries.join(', ')}`,

--- a/scripts/package-markdown.test.ts
+++ b/scripts/package-markdown.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
   apiAnchorFragments,
+  expandApiPlaceholders,
   extractPackageReadme,
   normalizePackageMarkdown,
   rewritePackageDocLinks,
@@ -195,6 +196,19 @@ test('rewrites package-relative guide and API links', () => {
     rewritePackageDocLinks(markdown, apiAnchorFragments(api)),
     'See [Installation](/docs/readme#installation), [initialize](/docs/api#method-initialize(...)), [`AdMobError`](/docs/api#interface-admoberror), [API](/docs/api), [Banner](/docs/banner), and [guides](/docs/consent).',
   );
+});
+
+test('expands bare and HTML-commented API placeholders', () => {
+  const api = new Map([['createPaymentSheet', '#### `method` createPaymentSheet(...)\n']]);
+  assert.equal(
+    expandApiPlaceholders('Before\n\n!::createPaymentSheet::\n\nAfter\n', api).expanded,
+    'Before\n\n#### `method` createPaymentSheet(...)\n\n\nAfter\n',
+  );
+  assert.equal(
+    expandApiPlaceholders('Before\n\n<!-- !::createPaymentSheet:: -->\n\nAfter\n', api).expanded,
+    'Before\n\n#### `method` createPaymentSheet(...)\n\n\nAfter\n',
+  );
+  assert.deepEqual(expandApiPlaceholders('!::missing::\n', api).missing, ['missing']);
 });
 
 test('rewrites nested package-relative guide links', () => {

--- a/scripts/package-markdown.test.ts
+++ b/scripts/package-markdown.test.ts
@@ -196,3 +196,13 @@ test('rewrites package-relative guide and API links', () => {
     'See [Installation](/docs/readme#installation), [initialize](/docs/api#method-initialize(...)), [`AdMobError`](/docs/api#interface-admoberror), [API](/docs/api), [Banner](/docs/banner), and [guides](/docs/consent).',
   );
 });
+
+test('rewrites nested package-relative guide links', () => {
+  assert.equal(
+    rewritePackageDocLinks(
+      'See [Event Listeners](./docs/learn/event-listeners.md) and [the same page](./learn/event-listeners.md).',
+      new Map(),
+    ),
+    'See [Event Listeners](/docs/learn/event-listeners) and [the same page](/docs/learn/event-listeners).',
+  );
+});

--- a/scripts/package-markdown.ts
+++ b/scripts/package-markdown.ts
@@ -137,7 +137,7 @@ export function rewritePackageDocLinks(
       return `](/docs/${landingSlug}${hash})`;
     }
 
-    const docFile = path.match(/^(?:\.\.\/)?(?:\.\/)?(?:docs\/)?([a-z0-9-]+)\.md$/i);
+    const docFile = path.match(/^(?:\.\.\/)?(?:\.\/)?(?:docs\/)?((?:[a-z0-9-]+\/)*[a-z0-9-]+)\.md$/i);
     if (docFile) return `](/docs/${docFile[1]}${hash})`;
     return match;
   });

--- a/scripts/package-markdown.ts
+++ b/scripts/package-markdown.ts
@@ -100,6 +100,21 @@ export function stripLeadingH1(markdown: string): string {
   return markdown.replace(/^# [^\n]+\r?\n+/, '');
 }
 
+const API_PLACEHOLDER = /^(?:<!--\s*)?!::([a-zA-Z0-9]+)::(?:\s*-->)?[ \t]*$/gm;
+
+export function expandApiPlaceholders(
+  markdown: string,
+  api: Map<string, string>,
+): { expanded: string; missing: string[] } {
+  const missing: string[] = [];
+  const expanded = markdown.replace(API_PLACEHOLDER, (_, id: string) => {
+    const entry = api.get(id);
+    if (!entry) missing.push(id);
+    return entry ?? '';
+  });
+  return { expanded, missing };
+}
+
 export function apiAnchorFragments(api: Map<string, string>): Map<string, string> {
   const fragments = new Map<string, string>();
   for (const [name, markdown] of api) {

--- a/scripts/package-markdown.ts
+++ b/scripts/package-markdown.ts
@@ -152,7 +152,9 @@ export function rewritePackageDocLinks(
       return `](/docs/${landingSlug}${hash})`;
     }
 
-    const docFile = path.match(/^(?:\.\.\/)?(?:\.\/)?(?:docs\/)?((?:[a-z0-9-]+\/)*[a-z0-9-]+)\.md$/i);
+    const docFile = path.match(
+      /^(?:\.\.\/)?(?:\.\/)?(?:docs\/)?((?:[a-z0-9-]+\/)*[a-z0-9-]+)\.md$/i,
+    );
     if (docFile) return `](/docs/${docFile[1]}${hash})`;
     return match;
   });


### PR DESCRIPTION
## Summary
- Allow `englishFromPackage` guides to rewrite nested markdown links such as `docs/learn/event-listeners.md` to `/docs/learn/event-listeners`.

## Test plan
- [ ] `node --import tsx --test scripts/package-markdown.test.ts`
- [ ] Confirm Stripe Event Listeners links resolve after `englishFromPackage` is enabled.


Made with [Cursor](https://cursor.com)