### PR TITLE
chore: update repository name to website

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       RDLABO_DOCS_REF: ${{ github.event.pull_request.head.sha || github.sha }}
-      RDLABO_DOCS_REPOSITORY_URL: ${{ github.event.pull_request.head.repo.html_url || 'https://github.com/rdlabo-dev/docs' }}
+      RDLABO_DOCS_REPOSITORY_URL: ${{ github.event.pull_request.head.repo.html_url || 'https://github.com/rdlabo-dev/website' }}
     steps:
       - uses: actions/checkout@v5
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@
 `docs:generate` **always** loads English from GitHub raw — never from the local filesystem. Resolution order:
 
 1. Package repository: `docs/{file}`, `{sourceDirectory}/docs/{file}`, then `README.md` for landings.
-2. Portal repository (`rdlabo-dev/docs`): `src/{sourceDirectory}/docs/{file}`.
+2. Portal repository (`rdlabo-dev/website`): `src/{sourceDirectory}/docs/{file}`.
 
 For `@capacitor-community/admob` and rdlabo Capacitor plugins, English lives in the **package repository only** — do not copy those English files into `src/{project}/docs/`.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Documentation portal for personal open source projects created and maintained by
 
 The `rdlabo` name is also used by 一般社団法人リレーションデザイン研究所, but every OSS project documented here is owned and maintained personally by rdlabo. This portal and its projects are not activities of that incorporated association.
 
-Production is `docs.rdlabo.dev` on Cloudflare Workers Static Assets. The repository is `rdlabo-dev/docs`.
+Production is `docs.rdlabo.dev` on Cloudflare Workers Static Assets. The repository is `rdlabo-dev/website`.
 
 ## Current projects
 

--- a/scripts/generate-docs.ts
+++ b/scripts/generate-docs.ts
@@ -34,7 +34,7 @@ import {
 } from './package-markdown';
 
 const root = resolve(process.cwd());
-const docsRepositoryUrl = 'https://github.com/rdlabo-dev/docs';
+const docsRepositoryUrl = 'https://github.com/rdlabo-dev/website';
 
 const stripHtml = (value: string) => value.replace(/<\/?code>/g, '`').replace(/<[^>]+>/g, '');
 const tagText = (tags: any[], name: string) => tags?.find((tag) => tag.name === name)?.text ?? '';

--- a/scripts/package-repository.test.ts
+++ b/scripts/package-repository.test.ts
@@ -55,7 +55,7 @@ test('builds raw and source labels for repository docs', () => {
     repositorySourceLabel(repositoryUrl, 'main', 'README.md'),
     'capacitor-community/admob@main/README.md',
   );
-  assert.equal(CANONICAL_DOCS_PORTAL_REPOSITORY_URL, 'https://github.com/rdlabo-dev/docs');
+  assert.equal(CANONICAL_DOCS_PORTAL_REPOSITORY_URL, 'https://github.com/rdlabo-dev/website');
   assert.equal(
     DOCS_PORTAL_REPOSITORY_URL,
     process.env['RDLABO_DOCS_REPOSITORY_URL'] ?? CANONICAL_DOCS_PORTAL_REPOSITORY_URL,
@@ -75,7 +75,7 @@ test('keeps fork-fetched portal pages editable in the canonical repository', () 
       content: '# API',
       repositoryPath: 'src/example/docs/api.md',
       repositoryRef: 'main',
-      repositoryUrl: 'https://github.com/rdlabo-dev/docs',
+      repositoryUrl: 'https://github.com/rdlabo-dev/website',
     },
   );
 });

--- a/scripts/package-repository.ts
+++ b/scripts/package-repository.ts
@@ -8,7 +8,7 @@ export interface RepositoryCoordinates {
   repo: string;
 }
 
-export const CANONICAL_DOCS_PORTAL_REPOSITORY_URL = 'https://github.com/rdlabo-dev/docs';
+export const CANONICAL_DOCS_PORTAL_REPOSITORY_URL = 'https://github.com/rdlabo-dev/website';
 export const DOCS_PORTAL_REPOSITORY_URL =
   process.env['RDLABO_DOCS_REPOSITORY_URL'] ?? CANONICAL_DOCS_PORTAL_REPOSITORY_URL;
 

--- a/scripts/site-contract.test.ts
+++ b/scripts/site-contract.test.ts
@@ -115,7 +115,7 @@ test('rdlabo brand logo title is English-only', async () => {
 test('uses the rdlabo-dev GitHub owner throughout site sources', async () => {
   const legacyOwner = ['rdlabo', 'team'].join('-');
   const legacyDocsRepository = ['ionic-jp', 'capacitor-plugins-docs'].join('/');
-  const docsRepositoryUrl = 'https://github.com/rdlabo-dev/docs';
+  const docsRepositoryUrl = 'https://github.com/rdlabo-dev/website';
   const roots = [
     new URL('../README.md', import.meta.url),
     new URL('../scripts/', import.meta.url),
@@ -150,7 +150,7 @@ test('uses the rdlabo-dev GitHub owner throughout site sources', async () => {
   assert.match(generateDocs, /\$\{docsRepositoryUrl\}\/edit\/main\//);
 
   const readme = await readFile(new URL('../README.md', import.meta.url), 'utf8');
-  assert.match(readme, /`rdlabo-dev\/docs`/);
+  assert.match(readme, /`rdlabo-dev\/website`/);
   assert.doesNotMatch(readme, /later rollout/);
 });
 

--- a/src/app/docs/github-stars.service.spec.ts
+++ b/src/app/docs/github-stars.service.spec.ts
@@ -13,9 +13,9 @@ describe('GitHubStarsService', () => {
     vi.stubGlobal('fetch', fetchMock);
 
     const service = TestBed.inject(GitHubStarsService);
-    await expect(service.count('https://github.com/rdlabo-dev/docs')).resolves.toBe(42);
-    await expect(service.count('https://github.com/rdlabo-dev/docs')).resolves.toBe(42);
-    expect(fetchMock).toHaveBeenCalledWith('https://api.github.com/repos/rdlabo-dev/docs', {
+    await expect(service.count('https://github.com/rdlabo-dev/website')).resolves.toBe(42);
+    await expect(service.count('https://github.com/rdlabo-dev/website')).resolves.toBe(42);
+    expect(fetchMock).toHaveBeenCalledWith('https://api.github.com/repos/rdlabo-dev/website', {
       headers: { Accept: 'application/vnd.github+json' },
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -30,6 +30,6 @@ describe('GitHubStarsService', () => {
     expect(fetchMock).not.toHaveBeenCalled();
 
     fetchMock.mockResolvedValue({ ok: false });
-    await expect(service.count('https://github.com/rdlabo-dev/docs')).resolves.toBeUndefined();
+    await expect(service.count('https://github.com/rdlabo-dev/website')).resolves.toBeUndefined();
   });
 });

--- a/src/app/generated/projects/admob.ja.generated.ts
+++ b/src/app/generated/projects/admob.ja.generated.ts
@@ -100,7 +100,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/admob/docs/ja/readme.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/admob/docs/ja/readme.md"
     },
     {
       "title": "初期化",
@@ -124,7 +124,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/admob/docs/ja/configuration.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/admob/docs/ja/configuration.md"
     },
     {
       "title": "同意管理",
@@ -208,7 +208,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/admob/docs/ja/consent.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/admob/docs/ja/consent.md"
     },
     {
       "title": "バナー広告",
@@ -267,7 +267,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/admob/docs/ja/banner.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/admob/docs/ja/banner.md"
     },
     {
       "title": "インタースティシャル広告",
@@ -301,7 +301,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/admob/docs/ja/interstitial.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/admob/docs/ja/interstitial.md"
     },
     {
       "title": "リワード広告",
@@ -375,7 +375,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/admob/docs/ja/rewarded.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/admob/docs/ja/rewarded.md"
     },
     {
       "title": "アプリ起動時広告",
@@ -409,7 +409,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/admob/docs/ja/app-open.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/admob/docs/ja/app-open.md"
     },
     {
       "title": "広告イベント",
@@ -653,7 +653,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/admob/docs/ja/events.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/admob/docs/ja/events.md"
     },
     {
       "title": "テスト",
@@ -712,7 +712,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/admob/docs/ja/testing.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/admob/docs/ja/testing.md"
     },
     {
       "title": "移行",
@@ -751,7 +751,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/admob/docs/ja/migration.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/admob/docs/ja/migration.md"
     },
     {
       "title": "API",

--- a/src/app/generated/projects/capacitor-brotherprint.ja.generated.ts
+++ b/src/app/generated/projects/capacitor-brotherprint.ja.generated.ts
@@ -56,7 +56,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/capacitor-brotherprint/docs/ja/readme.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/capacitor-brotherprint/docs/ja/readme.md"
     },
     {
       "title": "インストール",
@@ -105,7 +105,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/capacitor-brotherprint/docs/ja/installation.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/capacitor-brotherprint/docs/ja/installation.md"
     },
     {
       "title": "Search",
@@ -169,7 +169,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/capacitor-brotherprint/docs/ja/search.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/capacitor-brotherprint/docs/ja/search.md"
     },
     {
       "title": "Print",
@@ -193,7 +193,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/capacitor-brotherprint/docs/ja/print.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/capacitor-brotherprint/docs/ja/print.md"
     },
     {
       "title": "Events",
@@ -242,7 +242,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/capacitor-brotherprint/docs/ja/events.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/capacitor-brotherprint/docs/ja/events.md"
     },
     {
       "title": "API",

--- a/src/app/generated/projects/capacitor-codescanner.ja.generated.ts
+++ b/src/app/generated/projects/capacitor-codescanner.ja.generated.ts
@@ -66,7 +66,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/capacitor-codescanner/docs/ja/readme.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/capacitor-codescanner/docs/ja/readme.md"
     },
     {
       "title": "CodeScanner",
@@ -115,7 +115,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/capacitor-codescanner/docs/ja/code-scanner.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/capacitor-codescanner/docs/ja/code-scanner.md"
     },
     {
       "title": "API",

--- a/src/app/generated/projects/capacitor-docgen.en.generated.ts
+++ b/src/app/generated/projects/capacitor-docgen.en.generated.ts
@@ -185,7 +185,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/capacitor-docgen/docs/api.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/capacitor-docgen/docs/api.md"
     }
   ]
 } as const;

--- a/src/app/generated/projects/capacitor-docgen.ja.generated.ts
+++ b/src/app/generated/projects/capacitor-docgen.ja.generated.ts
@@ -52,7 +52,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/capacitor-docgen/docs/ja/getting-started.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/capacitor-docgen/docs/ja/getting-started.md"
     },
     {
       "title": "本家との差分",
@@ -91,7 +91,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/capacitor-docgen/docs/ja/upstream-differences.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/capacitor-docgen/docs/ja/upstream-differences.md"
     },
     {
       "title": "API",
@@ -180,7 +180,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/capacitor-docgen/docs/ja/api.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/capacitor-docgen/docs/ja/api.md"
     }
   ]
 } as const;

--- a/src/app/generated/projects/capacitor-printer.ja.generated.ts
+++ b/src/app/generated/projects/capacitor-printer.ja.generated.ts
@@ -61,7 +61,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/capacitor-printer/docs/ja/readme.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/capacitor-printer/docs/ja/readme.md"
     },
     {
       "title": "PDF",
@@ -85,7 +85,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/capacitor-printer/docs/ja/pdf.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/capacitor-printer/docs/ja/pdf.md"
     },
     {
       "title": "Web",
@@ -109,7 +109,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/capacitor-printer/docs/ja/web.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/capacitor-printer/docs/ja/web.md"
     },
     {
       "title": "API",

--- a/src/app/generated/projects/capacitor-screenshot-event.ja.generated.ts
+++ b/src/app/generated/projects/capacitor-screenshot-event.ja.generated.ts
@@ -61,7 +61,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/capacitor-screenshot-event/docs/ja/readme.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/capacitor-screenshot-event/docs/ja/readme.md"
     },
     {
       "title": "ScreenshotEvent",
@@ -110,7 +110,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/capacitor-screenshot-event/docs/ja/screenshot-event.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/capacitor-screenshot-event/docs/ja/screenshot-event.md"
     },
     {
       "title": "API",

--- a/src/app/generated/projects/eslint-plugin-rules.en.generated.ts
+++ b/src/app/generated/projects/eslint-plugin-rules.en.generated.ts
@@ -191,7 +191,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/eslint-plugin-rules/docs/api.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/eslint-plugin-rules/docs/api.md"
     },
     {
       "title": "component-property-use-readonly",

--- a/src/app/generated/projects/eslint-plugin-rules.ja.generated.ts
+++ b/src/app/generated/projects/eslint-plugin-rules.ja.generated.ts
@@ -55,7 +55,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/eslint-plugin-rules/docs/ja/getting-started.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/eslint-plugin-rules/docs/ja/getting-started.md"
     },
     {
       "title": "設定",
@@ -84,7 +84,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/eslint-plugin-rules/docs/ja/configuration.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/eslint-plugin-rules/docs/ja/configuration.md"
     },
     {
       "title": "移行",
@@ -123,7 +123,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/eslint-plugin-rules/docs/ja/migration.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/eslint-plugin-rules/docs/ja/migration.md"
     },
     {
       "title": "ルール一覧",
@@ -147,7 +147,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/eslint-plugin-rules/docs/ja/rules.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/eslint-plugin-rules/docs/ja/rules.md"
     },
     {
       "title": "API",
@@ -181,7 +181,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/eslint-plugin-rules/docs/ja/api.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/eslint-plugin-rules/docs/ja/api.md"
     },
     {
       "title": "component-property-use-readonly",
@@ -235,7 +235,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/eslint-plugin-rules/docs/ja/rules/component-property-use-readonly.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/eslint-plugin-rules/docs/ja/rules/component-property-use-readonly.md"
     },
     {
       "title": "deny-constructor-di",
@@ -284,7 +284,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/eslint-plugin-rules/docs/ja/rules/deny-constructor-di.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/eslint-plugin-rules/docs/ja/rules/deny-constructor-di.md"
     },
     {
       "title": "deny-element",
@@ -343,7 +343,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/eslint-plugin-rules/docs/ja/rules/deny-element.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/eslint-plugin-rules/docs/ja/rules/deny-element.md"
     },
     {
       "title": "deny-overlay-create",
@@ -402,7 +402,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/eslint-plugin-rules/docs/ja/rules/deny-overlay-create.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/eslint-plugin-rules/docs/ja/rules/deny-overlay-create.md"
     },
     {
       "title": "deny-soft-private-modifier",
@@ -426,7 +426,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/eslint-plugin-rules/docs/ja/rules/deny-soft-private-modifier.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/eslint-plugin-rules/docs/ja/rules/deny-soft-private-modifier.md"
     },
     {
       "title": "implements-ionic-lifecycle",
@@ -475,7 +475,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/eslint-plugin-rules/docs/ja/rules/implements-ionic-lifecycle.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/eslint-plugin-rules/docs/ja/rules/implements-ionic-lifecycle.md"
     },
     {
       "title": "ionic-attr-type-check",
@@ -529,7 +529,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/eslint-plugin-rules/docs/ja/rules/ionic-attr-type-check.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/eslint-plugin-rules/docs/ja/rules/ionic-attr-type-check.md"
     },
     {
       "title": "no-component-method-except-lifecycle",
@@ -573,7 +573,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/eslint-plugin-rules/docs/ja/rules/no-component-method-except-lifecycle.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/eslint-plugin-rules/docs/ja/rules/no-component-method-except-lifecycle.md"
     },
     {
       "title": "no-component-writable-signal",
@@ -627,7 +627,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/eslint-plugin-rules/docs/ja/rules/no-component-writable-signal.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/eslint-plugin-rules/docs/ja/rules/no-component-writable-signal.md"
     },
     {
       "title": "no-reactive-forms",
@@ -681,7 +681,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/eslint-plugin-rules/docs/ja/rules/no-reactive-forms.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/eslint-plugin-rules/docs/ja/rules/no-reactive-forms.md"
     },
     {
       "title": "no-template-driven-forms",
@@ -740,7 +740,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/eslint-plugin-rules/docs/ja/rules/no-template-driven-forms.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/eslint-plugin-rules/docs/ja/rules/no-template-driven-forms.md"
     },
     {
       "title": "prefer-disable-handler",
@@ -819,7 +819,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/eslint-plugin-rules/docs/ja/rules/prefer-disable-handler.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/eslint-plugin-rules/docs/ja/rules/prefer-disable-handler.md"
     },
     {
       "title": "prefer-ionic-standalone",
@@ -868,7 +868,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/eslint-plugin-rules/docs/ja/rules/prefer-ionic-standalone.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/eslint-plugin-rules/docs/ja/rules/prefer-ionic-standalone.md"
     },
     {
       "title": "prefer-modal-launcher",
@@ -937,7 +937,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/eslint-plugin-rules/docs/ja/rules/prefer-modal-launcher.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/eslint-plugin-rules/docs/ja/rules/prefer-modal-launcher.md"
     },
     {
       "title": "require-ion-item-group",
@@ -991,7 +991,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/eslint-plugin-rules/docs/ja/rules/require-ion-item-group.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/eslint-plugin-rules/docs/ja/rules/require-ion-item-group.md"
     },
     {
       "title": "require-viewmodel",
@@ -1075,7 +1075,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/eslint-plugin-rules/docs/ja/rules/require-viewmodel.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/eslint-plugin-rules/docs/ja/rules/require-viewmodel.md"
     },
     {
       "title": "restrict-try-block",
@@ -1154,7 +1154,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/eslint-plugin-rules/docs/ja/rules/restrict-try-block.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/eslint-plugin-rules/docs/ja/rules/restrict-try-block.md"
     },
     {
       "title": "signal-use-as-signal-template",
@@ -1213,7 +1213,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/eslint-plugin-rules/docs/ja/rules/signal-use-as-signal-template.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/eslint-plugin-rules/docs/ja/rules/signal-use-as-signal-template.md"
     },
     {
       "title": "signal-use-as-signal",
@@ -1272,7 +1272,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/eslint-plugin-rules/docs/ja/rules/signal-use-as-signal.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/eslint-plugin-rules/docs/ja/rules/signal-use-as-signal.md"
     }
   ]
 } as const;

--- a/src/app/generated/projects/facebook-login.ja.generated.ts
+++ b/src/app/generated/projects/facebook-login.ja.generated.ts
@@ -70,7 +70,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/facebook-login/docs/ja/readme.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/facebook-login/docs/ja/readme.md"
     },
     {
       "title": "設定",
@@ -109,7 +109,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/facebook-login/docs/ja/configuration.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/facebook-login/docs/ja/configuration.md"
     },
     {
       "title": "認証",
@@ -158,7 +158,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/facebook-login/docs/ja/authentication.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/facebook-login/docs/ja/authentication.md"
     },
     {
       "title": "App Events",
@@ -187,7 +187,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/facebook-login/docs/ja/app-events.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/facebook-login/docs/ja/app-events.md"
     },
     {
       "title": "API",

--- a/src/app/generated/projects/ionic-angular-collect-icons.en.generated.ts
+++ b/src/app/generated/projects/ionic-angular-collect-icons.en.generated.ts
@@ -259,7 +259,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ionic-angular-collect-icons/docs/api.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ionic-angular-collect-icons/docs/api.md"
     }
   ]
 } as const;

--- a/src/app/generated/projects/ionic-angular-collect-icons.ja.generated.ts
+++ b/src/app/generated/projects/ionic-angular-collect-icons.ja.generated.ts
@@ -71,7 +71,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ionic-angular-collect-icons/docs/ja/readme.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ionic-angular-collect-icons/docs/ja/readme.md"
     },
     {
       "title": "初期化",
@@ -110,7 +110,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ionic-angular-collect-icons/docs/ja/initialize.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ionic-angular-collect-icons/docs/ja/initialize.md"
     },
     {
       "title": "使い方",
@@ -129,7 +129,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ionic-angular-collect-icons/docs/ja/usage.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ionic-angular-collect-icons/docs/ja/usage.md"
     },
     {
       "title": "CLI オプション",
@@ -168,7 +168,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ionic-angular-collect-icons/docs/ja/options.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ionic-angular-collect-icons/docs/ja/options.md"
     },
     {
       "title": "FAQ",
@@ -181,7 +181,7 @@ export const PROJECT = {
       "headings": [],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ionic-angular-collect-icons/docs/ja/faq.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ionic-angular-collect-icons/docs/ja/faq.md"
     },
     {
       "title": "移行",
@@ -235,7 +235,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ionic-angular-collect-icons/docs/ja/migration.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ionic-angular-collect-icons/docs/ja/migration.md"
     },
     {
       "title": "CLI API",
@@ -259,7 +259,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ionic-angular-collect-icons/docs/ja/api.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ionic-angular-collect-icons/docs/ja/api.md"
     }
   ]
 } as const;

--- a/src/app/generated/projects/ionic-angular-kit.en.generated.ts
+++ b/src/app/generated/projects/ionic-angular-kit.en.generated.ts
@@ -240,7 +240,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ionic-angular-kit/docs/api.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ionic-angular-kit/docs/api.md"
     }
   ]
 } as const;

--- a/src/app/generated/projects/ionic-angular-kit.ja.generated.ts
+++ b/src/app/generated/projects/ionic-angular-kit.ja.generated.ts
@@ -60,7 +60,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ionic-angular-kit/docs/ja/getting-started.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ionic-angular-kit/docs/ja/getting-started.md"
     },
     {
       "title": "Storage・Overlay",
@@ -84,7 +84,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ionic-angular-kit/docs/ja/storage-overlays.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ionic-angular-kit/docs/ja/storage-overlays.md"
     },
     {
       "title": "認証・HTTP",
@@ -108,7 +108,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ionic-angular-kit/docs/ja/auth-http.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ionic-angular-kit/docs/ja/auth-http.md"
     },
     {
       "title": "Offline・Realtime",
@@ -132,7 +132,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ionic-angular-kit/docs/ja/offline-realtime.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ionic-angular-kit/docs/ja/offline-realtime.md"
     },
     {
       "title": "任意機能",
@@ -166,7 +166,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ionic-angular-kit/docs/ja/optional-features.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ionic-angular-kit/docs/ja/optional-features.md"
     },
     {
       "title": "API",
@@ -235,7 +235,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ionic-angular-kit/docs/ja/api.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ionic-angular-kit/docs/ja/api.md"
     }
   ]
 } as const;

--- a/src/app/generated/projects/ionic-angular-photo-editor.en.generated.ts
+++ b/src/app/generated/projects/ionic-angular-photo-editor.en.generated.ts
@@ -316,7 +316,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ionic-angular-photo-editor/docs/api.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ionic-angular-photo-editor/docs/api.md"
     }
   ]
 } as const;

--- a/src/app/generated/projects/ionic-angular-photo-editor.ja.generated.ts
+++ b/src/app/generated/projects/ionic-angular-photo-editor.ja.generated.ts
@@ -71,7 +71,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ionic-angular-photo-editor/docs/ja/readme.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ionic-angular-photo-editor/docs/ja/readme.md"
     },
     {
       "title": "テーマ",
@@ -95,7 +95,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ionic-angular-photo-editor/docs/ja/theme.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ionic-angular-photo-editor/docs/ja/theme.md"
     },
     {
       "title": "PhotoFileService",
@@ -114,7 +114,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ionic-angular-photo-editor/docs/ja/photo-file.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ionic-angular-photo-editor/docs/ja/photo-file.md"
     },
     {
       "title": "Photo Editor",
@@ -153,7 +153,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ionic-angular-photo-editor/docs/ja/editor.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ionic-angular-photo-editor/docs/ja/editor.md"
     },
     {
       "title": "Photo Viewer",
@@ -207,7 +207,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ionic-angular-photo-editor/docs/ja/viewer.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ionic-angular-photo-editor/docs/ja/viewer.md"
     },
     {
       "title": "API",
@@ -316,7 +316,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ionic-angular-photo-editor/docs/ja/api.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ionic-angular-photo-editor/docs/ja/api.md"
     }
   ]
 } as const;

--- a/src/app/generated/projects/ionic-angular-scroll-header.en.generated.ts
+++ b/src/app/generated/projects/ionic-angular-scroll-header.en.generated.ts
@@ -161,7 +161,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ionic-angular-scroll-header/docs/api.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ionic-angular-scroll-header/docs/api.md"
     }
   ]
 } as const;

--- a/src/app/generated/projects/ionic-angular-scroll-header.ja.generated.ts
+++ b/src/app/generated/projects/ionic-angular-scroll-header.ja.generated.ts
@@ -71,7 +71,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ionic-angular-scroll-header/docs/ja/readme.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ionic-angular-scroll-header/docs/ja/readme.md"
     },
     {
       "title": "IonContent",
@@ -84,7 +84,7 @@ export const PROJECT = {
       "headings": [],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ionic-angular-scroll-header/docs/ja/ion-content.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ionic-angular-scroll-header/docs/ja/ion-content.md"
     },
     {
       "title": "Virtual Scroll",
@@ -103,7 +103,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ionic-angular-scroll-header/docs/ja/virtual-scroll.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ionic-angular-scroll-header/docs/ja/virtual-scroll.md"
     },
     {
       "title": "Safe Area",
@@ -127,7 +127,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ionic-angular-scroll-header/docs/ja/safe-area.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ionic-angular-scroll-header/docs/ja/safe-area.md"
     },
     {
       "title": "API",
@@ -161,7 +161,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ionic-angular-scroll-header/docs/ja/api.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ionic-angular-scroll-header/docs/ja/api.md"
     }
   ]
 } as const;

--- a/src/app/generated/projects/ionic-theme-ios26.en.generated.ts
+++ b/src/app/generated/projects/ionic-theme-ios26.en.generated.ts
@@ -359,7 +359,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ionic-theme-ios26/docs/api.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ionic-theme-ios26/docs/api.md"
     }
   ]
 } as const;

--- a/src/app/generated/projects/ionic-theme-ios26.ja.generated.ts
+++ b/src/app/generated/projects/ionic-theme-ios26.ja.generated.ts
@@ -66,7 +66,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ionic-theme-ios26/docs/ja/readme.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ionic-theme-ios26/docs/ja/readme.md"
     },
     {
       "title": "ion-item-groupの使用方法",
@@ -95,7 +95,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ionic-theme-ios26/docs/ja/using-ion-item-group.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ionic-theme-ios26/docs/ja/using-ion-item-group.md"
     },
     {
       "title": "機能",
@@ -134,7 +134,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ionic-theme-ios26/docs/ja/features.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ionic-theme-ios26/docs/ja/features.md"
     },
     {
       "title": "特別なマークアップとクラス",
@@ -183,7 +183,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ionic-theme-ios26/docs/ja/special-markup.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ionic-theme-ios26/docs/ja/special-markup.md"
     },
     {
       "title": "実験的なアニメーション",
@@ -207,7 +207,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ionic-theme-ios26/docs/ja/experimental-animation.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ionic-theme-ios26/docs/ja/experimental-animation.md"
     },
     {
       "title": "iOS 18",
@@ -226,7 +226,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ionic-theme-ios26/docs/ja/ios-18.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ionic-theme-ios26/docs/ja/ios-18.md"
     },
     {
       "title": "移行",
@@ -280,7 +280,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ionic-theme-ios26/docs/ja/migration.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ionic-theme-ios26/docs/ja/migration.md"
     },
     {
       "title": "API",
@@ -359,7 +359,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ionic-theme-ios26/docs/ja/api.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ionic-theme-ios26/docs/ja/api.md"
     }
   ]
 } as const;

--- a/src/app/generated/projects/ionic-theme-md3.en.generated.ts
+++ b/src/app/generated/projects/ionic-theme-md3.en.generated.ts
@@ -177,7 +177,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ionic-theme-md3/docs/api.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ionic-theme-md3/docs/api.md"
     }
   ]
 } as const;

--- a/src/app/generated/projects/ionic-theme-md3.ja.generated.ts
+++ b/src/app/generated/projects/ionic-theme-md3.ja.generated.ts
@@ -71,7 +71,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ionic-theme-md3/docs/ja/readme.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ionic-theme-md3/docs/ja/readme.md"
     },
     {
       "title": "特別なマークアップ",
@@ -105,7 +105,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ionic-theme-md3/docs/ja/special-markup.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ionic-theme-md3/docs/ja/special-markup.md"
     },
     {
       "title": "ion-item-groupの使用方法",
@@ -129,7 +129,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ionic-theme-md3/docs/ja/using-ion-item-group.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ionic-theme-md3/docs/ja/using-ion-item-group.md"
     },
     {
       "title": "移行",
@@ -153,7 +153,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ionic-theme-md3/docs/ja/migration.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ionic-theme-md3/docs/ja/migration.md"
     },
     {
       "title": "API",
@@ -177,7 +177,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ionic-theme-md3/docs/ja/api.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ionic-theme-md3/docs/ja/api.md"
     }
   ]
 } as const;

--- a/src/app/generated/projects/ngx-cdk-scroll-strategies.en.generated.ts
+++ b/src/app/generated/projects/ngx-cdk-scroll-strategies.en.generated.ts
@@ -204,7 +204,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ngx-cdk-scroll-strategies/docs/api.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ngx-cdk-scroll-strategies/docs/api.md"
     }
   ]
 } as const;

--- a/src/app/generated/projects/ngx-cdk-scroll-strategies.ja.generated.ts
+++ b/src/app/generated/projects/ngx-cdk-scroll-strategies.ja.generated.ts
@@ -71,7 +71,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ngx-cdk-scroll-strategies/docs/ja/readme.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ngx-cdk-scroll-strategies/docs/ja/readme.md"
     },
     {
       "title": "シンプルな使い方",
@@ -84,7 +84,7 @@ export const PROJECT = {
       "headings": [],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ngx-cdk-scroll-strategies/docs/ja/simple.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ngx-cdk-scroll-strategies/docs/ja/simple.md"
     },
     {
       "title": "応用的な使い方",
@@ -97,7 +97,7 @@ export const PROJECT = {
       "headings": [],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ngx-cdk-scroll-strategies/docs/ja/advanced.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ngx-cdk-scroll-strategies/docs/ja/advanced.md"
     },
     {
       "title": "リバーススクロール",
@@ -116,7 +116,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ngx-cdk-scroll-strategies/docs/ja/reverse.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ngx-cdk-scroll-strategies/docs/ja/reverse.md"
     },
     {
       "title": "FAQ",
@@ -135,7 +135,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ngx-cdk-scroll-strategies/docs/ja/faq.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ngx-cdk-scroll-strategies/docs/ja/faq.md"
     },
     {
       "title": "API",
@@ -204,7 +204,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/ngx-cdk-scroll-strategies/docs/ja/api.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/ngx-cdk-scroll-strategies/docs/ja/api.md"
     }
   ]
 } as const;

--- a/src/app/generated/projects/stripe-identity.en.generated.ts
+++ b/src/app/generated/projects/stripe-identity.en.generated.ts
@@ -367,7 +367,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/stripe-identity/docs/api.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/stripe-identity/docs/api.md"
     }
   ]
 } as const;

--- a/src/app/generated/projects/stripe-identity.ja.generated.ts
+++ b/src/app/generated/projects/stripe-identity.ja.generated.ts
@@ -56,7 +56,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/stripe-identity/docs/ja/configuration.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/stripe-identity/docs/ja/configuration.md"
     },
     {
       "title": "本人確認シート",
@@ -268,7 +268,7 @@ export const PROJECT = {
           }
         }
       ],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/stripe-identity/docs/ja/identity-verification-sheet.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/stripe-identity/docs/ja/identity-verification-sheet.md"
     },
     {
       "title": "API",
@@ -367,7 +367,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/stripe-identity/docs/ja/api.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/stripe-identity/docs/ja/api.md"
     }
   ]
 } as const;

--- a/src/app/generated/projects/stripe-terminal.en.generated.ts
+++ b/src/app/generated/projects/stripe-terminal.en.generated.ts
@@ -1270,7 +1270,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/stripe-terminal/docs/api.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/stripe-terminal/docs/api.md"
     }
   ]
 } as const;

--- a/src/app/generated/projects/stripe-terminal.ja.generated.ts
+++ b/src/app/generated/projects/stripe-terminal.ja.generated.ts
@@ -75,7 +75,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/stripe-terminal/docs/ja/configuration.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/stripe-terminal/docs/ja/configuration.md"
     },
     {
       "title": "支払いを受け付ける",
@@ -394,7 +394,7 @@ export const PROJECT = {
           }
         }
       ],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/stripe-terminal/docs/ja/collect-a-payment.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/stripe-terminal/docs/ja/collect-a-payment.md"
     },
     {
       "title": "リーダーのライフサイクル",
@@ -682,7 +682,7 @@ export const PROJECT = {
           }
         }
       ],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/stripe-terminal/docs/ja/reader-lifecycle.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/stripe-terminal/docs/ja/reader-lifecycle.md"
     },
     {
       "title": "Tap to Pay",
@@ -886,7 +886,7 @@ export const PROJECT = {
           }
         }
       ],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/stripe-terminal/docs/ja/tap-to-pay.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/stripe-terminal/docs/ja/tap-to-pay.md"
     },
     {
       "title": "API",
@@ -1270,7 +1270,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/stripe-terminal/docs/ja/api.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/stripe-terminal/docs/ja/api.md"
     }
   ]
 } as const;

--- a/src/app/generated/projects/stripe.en.generated.ts
+++ b/src/app/generated/projects/stripe.en.generated.ts
@@ -1552,7 +1552,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/stripe/docs/api.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/stripe/docs/api.md"
     }
   ]
 } as const;

--- a/src/app/generated/projects/stripe.ja.generated.ts
+++ b/src/app/generated/projects/stripe.ja.generated.ts
@@ -64,7 +64,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/stripe/docs/ja/configuration.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/stripe/docs/ja/configuration.md"
     },
     {
       "title": "Vanilla JS クイックスタート",
@@ -77,7 +77,7 @@ export const PROJECT = {
       "headings": [],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/stripe/docs/ja/vanilla-js.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/stripe/docs/ja/vanilla-js.md"
     },
     {
       "title": "Angular クイックスタート",
@@ -96,7 +96,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/stripe/docs/ja/angular.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/stripe/docs/ja/angular.md"
     },
     {
       "title": "React クイックスタート",
@@ -115,7 +115,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/stripe/docs/ja/react.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/stripe/docs/ja/react.md"
     },
     {
       "title": "イベントリスナー",
@@ -299,7 +299,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/stripe/docs/ja/learn/event-listeners.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/stripe/docs/ja/learn/event-listeners.md"
     },
     {
       "title": "サーバー連携",
@@ -333,7 +333,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/stripe/docs/ja/server-integration.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/stripe/docs/ja/server-integration.md"
     },
     {
       "title": "プロジェクトで初期化する",
@@ -397,7 +397,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/stripe/docs/ja/initialize.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/stripe/docs/ja/initialize.md"
     },
     {
       "title": "PaymentSheet",
@@ -528,7 +528,7 @@ export const PROJECT = {
           }
         }
       ],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/stripe/docs/ja/payment-sheet.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/stripe/docs/ja/payment-sheet.md"
     },
     {
       "title": "PaymentFlow",
@@ -683,7 +683,7 @@ export const PROJECT = {
           }
         }
       ],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/stripe/docs/ja/payment-flow.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/stripe/docs/ja/payment-flow.md"
     },
     {
       "title": "Apple Pay",
@@ -877,7 +877,7 @@ export const PROJECT = {
           }
         }
       ],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/stripe/docs/ja/apple-pay.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/stripe/docs/ja/apple-pay.md"
     },
     {
       "title": "Google Pay",
@@ -1198,7 +1198,7 @@ export const PROJECT = {
           }
         }
       ],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/stripe/docs/ja/google-pay.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/stripe/docs/ja/google-pay.md"
     },
     {
       "title": "API",
@@ -1552,7 +1552,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/stripe/docs/ja/api.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/stripe/docs/ja/api.md"
     }
   ]
 } as const;

--- a/src/app/generated/projects/workers-hono-kit.ja.generated.ts
+++ b/src/app/generated/projects/workers-hono-kit.ja.generated.ts
@@ -50,7 +50,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/workers-hono-kit/docs/ja/getting-started.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/workers-hono-kit/docs/ja/getting-started.md"
     },
     {
       "title": "HTTP・認証",
@@ -84,7 +84,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/workers-hono-kit/docs/ja/http-auth.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/workers-hono-kit/docs/ja/http-auth.md"
     },
     {
       "title": "データ層",
@@ -113,7 +113,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/workers-hono-kit/docs/ja/data-layer.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/workers-hono-kit/docs/ja/data-layer.md"
     },
     {
       "title": "Realtime・Offline",
@@ -137,7 +137,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/workers-hono-kit/docs/ja/realtime-offline.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/workers-hono-kit/docs/ja/realtime-offline.md"
     },
     {
       "title": "テスト・運用",
@@ -171,7 +171,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/workers-hono-kit/docs/ja/testing-operations.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/workers-hono-kit/docs/ja/testing-operations.md"
     },
     {
       "title": "API",
@@ -220,7 +220,7 @@ export const PROJECT = {
       ],
       "codes": [],
       "scrollMap": [],
-      "editUrl": "https://github.com/rdlabo-dev/docs/edit/main/src/workers-hono-kit/docs/ja/api.md"
+      "editUrl": "https://github.com/rdlabo-dev/website/edit/main/src/workers-hono-kit/docs/ja/api.md"
     }
   ]
 } as const;

--- a/src/stripe-identity/config/packages.json
+++ b/src/stripe-identity/config/packages.json
@@ -1,6 +1,6 @@
 {
   "stripe-identity": {
     "name": "capacitor-community/stripe-identity",
-    "repository": "https://github.com/rdlabo-dev/docs/"
+    "repository": "https://github.com/rdlabo-dev/website/"
   }
 }

--- a/src/stripe-terminal/config/packages.json
+++ b/src/stripe-terminal/config/packages.json
@@ -1,6 +1,6 @@
 {
   "stripe-terminal": {
     "name": "capacitor-community/stripe-terminal",
-    "repository": "https://github.com/rdlabo-dev/docs/"
+    "repository": "https://github.com/rdlabo-dev/website/"
   }
 }

--- a/src/stripe/config/packages.json
+++ b/src/stripe/config/packages.json
@@ -1,10 +1,10 @@
 {
   "stripe": {
     "name": "capacitor-community/stripe",
-    "repository": "https://github.com/rdlabo-dev/docs/"
+    "repository": "https://github.com/rdlabo-dev/website/"
   },
   "stripe-identity": {
     "name": "capacitor-community/stripe-identity",
-    "repository": "https://github.com/rdlabo-dev/docs/"
+    "repository": "https://github.com/rdlabo-dev/website/"
   }
 }


### PR DESCRIPTION
## Summary

- Update canonical repository references from rdlabo-dev/docs to rdlabo-dev/website
- Update CI fallback URLs, source/edit links, README and AGENTS guidance, package configs, and test expectations
- Regenerate portal pages so every generated edit URL targets the renamed repository
- Update the local origin remote to rdlabo-dev/website

The mechanical repository-identity replacements and regeneration were delegated to Cursor Auto, then reviewed and verified manually. Documentation routes, the docs.rdlabo.dev domain, environment variable names, and generic fork examples were intentionally preserved.

## Verification

- Confirmed no rdlabo-dev/docs references remain outside ignored build/dependency directories
- npm run fmt:check
- npm run lint
- npm test: 48 Node tests and 38 Angular tests passed
- npm run build: production build and 8 static-output tests passed

The production build continues to report the existing initial bundle warning at 427.58 kB versus the 425 kB warning threshold; it remains below the error limit.