### PR TITLE
fix: mark Ionic theme article as published

### DIFF
--- a/projects/docs/src/app/docs/landing-page.spec.ts
+++ b/projects/docs/src/app/docs/landing-page.spec.ts
@@ -90,8 +90,11 @@ describe('LandingPageComponent', () => {
       ),
     ).toBe(true);
     const dates = Array.from(compiled.querySelectorAll<HTMLTimeElement>('time'));
-    expect(dates.map((date) => date.dateTime)).toEqual(['2026-08-24', '2026-08-24']);
-    expect(dates.every((date) => date.textContent?.includes('August 24, 2026'))).toBe(true);
+    expect(dates.map((date) => date.dateTime)).toEqual(['2026-08-25', '2026-08-24']);
+    expect(dates.map((date) => date.textContent?.trim())).toEqual([
+      'August 25, 2026',
+      'August 24, 2026',
+    ]);
     expect(compiled.querySelectorAll('.project-feature')).toHaveLength(3);
     expect(compiled.querySelectorAll('.project-feature a')).toHaveLength(0);
     expect(compiled.querySelectorAll('a.related-article-link')).toHaveLength(2);

--- a/projects/docs/src/app/generated/projects/ionic-theme-ios26.en.generated.ts
+++ b/projects/docs/src/app/generated/projects/ionic-theme-ios26.en.generated.ts
@@ -35,7 +35,7 @@ export const PROJECT = {
       "slug": "ionic-themes-ionic9-major-update",
       "title": "Bringing iOS 26 and Material Design 3 to Ionic: Both Themes Reach v9",
       "description": "The iOS 26 and Material Design 3 themes for Ionic now align with Ionic 9, adding two-line list items, supporting-text layouts, iOS outline fields, visual regression testing, and a smoother migration path.",
-      "publishedDate": "2026-08-24",
+      "publishedDate": "2026-08-25",
       "url": "https://rdlabo.dev/articles/ionic-themes-ionic9-major-update"
     },
     {

--- a/projects/docs/src/app/generated/projects/ionic-theme-ios26.ja.generated.ts
+++ b/projects/docs/src/app/generated/projects/ionic-theme-ios26.ja.generated.ts
@@ -35,7 +35,7 @@ export const PROJECT = {
       "slug": "ionic-themes-ionic9-major-update",
       "title": "Bringing iOS 26 and Material Design 3 to Ionic: Both Themes Reach v9",
       "description": "The iOS 26 and Material Design 3 themes for Ionic now align with Ionic 9, adding two-line list items, supporting-text layouts, iOS outline fields, visual regression testing, and a smoother migration path.",
-      "publishedDate": "2026-08-24",
+      "publishedDate": "2026-08-25",
       "url": "https://rdlabo.dev/articles/ionic-themes-ionic9-major-update"
     },
     {

--- a/projects/docs/src/app/generated/projects/ionic-theme-md3.en.generated.ts
+++ b/projects/docs/src/app/generated/projects/ionic-theme-md3.en.generated.ts
@@ -32,18 +32,18 @@ export const PROJECT = {
   "path": "/projects/ionic-theme-md3",
   "relatedArticles": [
     {
+      "slug": "ionic-themes-ionic9-major-update",
+      "title": "Bringing iOS 26 and Material Design 3 to Ionic: Both Themes Reach v9",
+      "description": "The iOS 26 and Material Design 3 themes for Ionic now align with Ionic 9, adding two-line list items, supporting-text layouts, iOS outline fields, visual regression testing, and a smoother migration path.",
+      "publishedDate": "2026-08-25",
+      "url": "https://rdlabo.dev/articles/ionic-themes-ionic9-major-update"
+    },
+    {
       "slug": "ionic-theme-md3",
       "title": "A Material Design 3 Theme for Ionic Has Grown into Something Really Good",
       "description": "@rdlabo/ionic-theme-md3 brings Material Design 3 to Ionic while preserving its components and markup, with dark mode, transitions, incremental adoption, and iOS 26 theme compatibility.",
       "publishedDate": "2026-08-24",
       "url": "https://rdlabo.dev/articles/ionic-theme-md3"
-    },
-    {
-      "slug": "ionic-themes-ionic9-major-update",
-      "title": "Bringing iOS 26 and Material Design 3 to Ionic: Both Themes Reach v9",
-      "description": "The iOS 26 and Material Design 3 themes for Ionic now align with Ionic 9, adding two-line list items, supporting-text layouts, iOS outline fields, visual regression testing, and a smoother migration path.",
-      "publishedDate": "2026-08-24",
-      "url": "https://rdlabo.dev/articles/ionic-themes-ionic9-major-update"
     }
   ],
   "pages": [

--- a/projects/docs/src/app/generated/projects/ionic-theme-md3.ja.generated.ts
+++ b/projects/docs/src/app/generated/projects/ionic-theme-md3.ja.generated.ts
@@ -32,18 +32,18 @@ export const PROJECT = {
   "path": "/projects/ionic-theme-md3",
   "relatedArticles": [
     {
+      "slug": "ionic-themes-ionic9-major-update",
+      "title": "Bringing iOS 26 and Material Design 3 to Ionic: Both Themes Reach v9",
+      "description": "The iOS 26 and Material Design 3 themes for Ionic now align with Ionic 9, adding two-line list items, supporting-text layouts, iOS outline fields, visual regression testing, and a smoother migration path.",
+      "publishedDate": "2026-08-25",
+      "url": "https://rdlabo.dev/articles/ionic-themes-ionic9-major-update"
+    },
+    {
       "slug": "ionic-theme-md3",
       "title": "A Material Design 3 Theme for Ionic Has Grown into Something Really Good",
       "description": "@rdlabo/ionic-theme-md3 brings Material Design 3 to Ionic while preserving its components and markup, with dark mode, transitions, incremental adoption, and iOS 26 theme compatibility.",
       "publishedDate": "2026-08-24",
       "url": "https://rdlabo.dev/articles/ionic-theme-md3"
-    },
-    {
-      "slug": "ionic-themes-ionic9-major-update",
-      "title": "Bringing iOS 26 and Material Design 3 to Ionic: Both Themes Reach v9",
-      "description": "The iOS 26 and Material Design 3 themes for Ionic now align with Ionic 9, adding two-line list items, supporting-text layouts, iOS outline fields, visual regression testing, and a smoother migration path.",
-      "publishedDate": "2026-08-24",
-      "url": "https://rdlabo.dev/articles/ionic-themes-ionic9-major-update"
     }
   ],
   "pages": [

--- a/projects/web-site/src/articles/ionic-themes-ionic9-major-update.md
+++ b/projects/web-site/src/articles/ionic-themes-ionic9-major-update.md
@@ -2,10 +2,7 @@
 title: "Bringing iOS 26 and Material Design 3 to Ionic: Both Themes Reach v9"
 description: "The iOS 26 and Material Design 3 themes for Ionic now align with Ionic 9, adding two-line list items, supporting-text layouts, iOS outline fields, visual regression testing, and a smoother migration path."
 zennSlug: ionic-themes-ionic9-major-update
-sourceVerification: pending
-sourceUrl: https://zenn.dev/rdlabo/articles/ionic-themes-ionic9-major-update
-publishedAt: "2026-08-24T17:20:00+09:00"
-publishedDate: "2026-08-24"
+publishedDate: "2026-08-25"
 relatedLibraries:
   - ionic-theme-ios26
   - ionic-theme-md3


### PR DESCRIPTION
## Summary
- remove pending-only Zenn source metadata now that the article is public
- use the canonical 2026-08-25 publication date in related-library entries
- update generated project metadata and date-order expectations

## Validation
- npm run fmt:check
- npm run lint
- npm test
- npm run build
- npm run seo:audit
- git diff --check
- senior review: no findings